### PR TITLE
Bump dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Synology Chat allows you to communicate easily and securely with an all-in-one, 
 [Compatibility](#compatibility)  
 [Usage](#usage)  <!-- delete if not using this section -->  
 [Resources](#resources)  
+[Versions](#Versions)
 
 ## Installation
 
@@ -65,3 +66,11 @@ This Node will help you to send messages to specific users in the chat. It can't
 * [Synology Chat](https://www.synology.com/en-us/dsm/feature/chat)
 * [Synology Chat Chatbot Documentation](https://kb.synology.com/en-us/DSM/tutorial/How_to_configure_webhooks_and_slash_commands_in_Chat_Integration#x_anchor_id5)
 
+
+## Versions
+
+| n8n-nodes-synology-chat version | synology-chat-communicator version | Changelog |
+|----------|:-------------:|------:|
+| 1.0.0 |  1.0.0 | [synology-chat-communicator@1.0.0](https://github.com/UlisesGascon/synology-chat-communicator/releases/tag/v1.0.0) |
+| 1.1.0 |  1.1.0 | [synology-chat-communicator@1.1.0](https://github.com/UlisesGascon/synology-chat-communicator/releases/tag/v1.1.0) |
+    

--- a/nodes/SynologyChat/SynologyChat.node.ts
+++ b/nodes/SynologyChat/SynologyChat.node.ts
@@ -83,7 +83,6 @@ export class SynologyChat implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 		const { token, baseUrl, ignoreSSLErrors } = await this.getCredentials('synologyChatApi')
-		const NodeTLSRejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED
 		const { sendDirectMessage } = synologyChatCommunicator({token, baseUrl, ignoreSSLErrors})
 
 		let item: INodeExecutionData;
@@ -107,12 +106,6 @@ export class SynologyChat implements INodeType {
 				item.json['mediaLink'] = mediaLink;
 				if(operation === 'sendMessage'){
 					item.json['response'] = await sendDirectMessage(userId, text, mediaLink)
-					
-					if(ignoreSSLErrors){
-						// Restoring the original TLS state to avoid side effects
-						// @SEE: https://github.com/UlisesGascon/synology-chat-communicator/blob/main/src/utils.js#L5
-						process.env.NODE_TLS_REJECT_UNAUTHORIZED = NodeTLSRejectUnauthorized
-					}
 				}
 				
 			} catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "synology-chat-communicator": "1.0.0"
+        "synology-chat-communicator": "1.1.0"
       },
       "devDependencies": {
         "@types/express": "4.17.6",
@@ -6593,9 +6593,9 @@
       }
     },
     "node_modules/synology-chat-communicator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/synology-chat-communicator/-/synology-chat-communicator-1.0.0.tgz",
-      "integrity": "sha512-RoSUqUyjde4NfGqpenny3JDcB3Az2P1Pp3KKp8jlhSbWj1wCYiSkK0KMcfp1A5Me7kWibxhjoIBygyTs13ckUg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/synology-chat-communicator/-/synology-chat-communicator-1.1.0.tgz",
+      "integrity": "sha512-AwvdW1FbuZuNCNn9ICHAxDqh08bH2Nvk0F7JkgHq4TLFlnFfnfD4OkY4+28yQURjiLQY0YC3+DuTyY3z/JYGew==",
       "dependencies": {
         "debug": "4.3.4",
         "got": "11.8.6"
@@ -12529,9 +12529,9 @@
       }
     },
     "synology-chat-communicator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/synology-chat-communicator/-/synology-chat-communicator-1.0.0.tgz",
-      "integrity": "sha512-RoSUqUyjde4NfGqpenny3JDcB3Az2P1Pp3KKp8jlhSbWj1wCYiSkK0KMcfp1A5Me7kWibxhjoIBygyTs13ckUg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/synology-chat-communicator/-/synology-chat-communicator-1.1.0.tgz",
+      "integrity": "sha512-AwvdW1FbuZuNCNn9ICHAxDqh08bH2Nvk0F7JkgHq4TLFlnFfnfD4OkY4+28yQURjiLQY0YC3+DuTyY3z/JYGew==",
       "requires": {
         "debug": "4.3.4",
         "got": "11.8.6"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "eslint": "8.34.0"
   },
   "dependencies": {
-    "synology-chat-communicator": "1.0.0"
+    "synology-chat-communicator": "1.1.0"
   }
 }


### PR DESCRIPTION
### Main changes

- Removed the management for  `NODE_TLS_REJECT_UNAUTHORIZED` environmental variable as it is not needed in this version
- Bump to `synology-chat-communicator@1.1.0`

### Changelog
- 97d4cb7 chore: bump to synology-chat-communicator by @UlisesGascon
- 73f2e81 docs: added versions by @UlisesGascon



